### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ npm install stae --save
 ## Basic Examples
 
 ```js
-import stae from 'stae'
+import { createClient } from 'stae'
 
 // create a basic readable API client, authed as you
-const api = stae.createClient({ key: 'your-account-key-from-municipal.systems' })
+const api = createClient({ key: 'your-account-key-from-municipal.systems' })
 
 // get a list of places available
 const { results } = await api.place.find()


### PR DESCRIPTION
`import stae from 'stae'` is coming out as undefined.

The index.js is instead exporting the client as a named export:

```js
export const createClient = ({ key, root='https://municipal.systems/', ...rest }={}) => {
  if (typeof key !== 'string') throw new Error('Invalid key option!')
  if (typeof root !== 'string') throw new Error('Invalid base option!')
  const opts = {
    ...rest,
    root,
    simple: true,
    options: { key, ...rest.options }
  }
  return createBaseClient(meta, opts)
}
```